### PR TITLE
Remove thecodingmachine/safe in favor of native PHP functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "php": "^8.4",
         "ext-pcntl": "*",
         "ext-rdkafka": "^6",
-        "psr/log": "^3",
-        "thecodingmachine/safe": "^2.2 || ^3"
+        "psr/log": "^3"
     },
     "require-dev": {
         "cdn77/coding-standard": "^7.4",
@@ -31,8 +30,7 @@
         "phpstan/phpstan": "2.1.44",
         "phpstan/phpstan-phpunit": "2.0.16",
         "phpstan/phpstan-strict-rules": "2.0.10",
-        "phpunit/phpunit": "^13.0",
-        "thecodingmachine/phpstan-safe-rule": "^1.0"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,9 +5,6 @@ parameters:
         - %currentWorkingDirectory%/tests
 
     ignoreErrors:
-        # Adds unnecessary maintanence overhead
-        - "~Class DateTime(Immutable)? is unsafe to use. Its methods can return FALSE instead of throwing an exception. Please add 'use Safe\\\\DateTime(Immutable)?;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library~"
-
         - '~Constant SimPod\\Kafka\\Clients\\(Consumer|Producer)\\.+?Config::[A-Z_]+ is unused.~'
 
 includes:

--- a/src/Clients/Consumer/KafkaConsumer.php
+++ b/src/Clients/Consumer/KafkaConsumer.php
@@ -14,7 +14,7 @@ use SimPod\Kafka\Clients\Consumer\Exception\IncompatibleStatus;
 
 use function array_map;
 use function rd_kafka_err2str;
-use function Safe\pcntl_signal_dispatch;
+use function pcntl_signal_dispatch;
 use function sprintf;
 
 use const RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS;

--- a/src/Clients/Consumer/KafkaConsumer.php
+++ b/src/Clients/Consumer/KafkaConsumer.php
@@ -13,8 +13,8 @@ use RdKafka\TopicPartition;
 use SimPod\Kafka\Clients\Consumer\Exception\IncompatibleStatus;
 
 use function array_map;
-use function rd_kafka_err2str;
 use function pcntl_signal_dispatch;
+use function rd_kafka_err2str;
 use function sprintf;
 
 use const RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS;

--- a/src/Clients/Consumer/WithSignalControl.php
+++ b/src/Clients/Consumer/WithSignalControl.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace SimPod\Kafka\Clients\Consumer;
 
-use Safe\Exceptions\PcntlException;
-
-use function Safe\pcntl_signal;
-use function Safe\pcntl_sigprocmask;
+use function pcntl_signal;
+use function pcntl_sigprocmask;
 
 use const SIG_BLOCK;
 use const SIG_DFL;
@@ -24,11 +22,7 @@ trait WithSignalControl
         $config->set('internal.termination.signal', SIGIO);
     }
 
-    /**
-     * @param callable():mixed $terminationCallback
-     *
-     * @throws PcntlException
-     */
+    /** @param callable():mixed $terminationCallback */
     private function registerSignals(callable $terminationCallback): void
     {
         pcntl_signal(SIGTERM, $terminationCallback);

--- a/tests/Clients/Consumer/Fixture/TestProducer.php
+++ b/tests/Clients/Consumer/Fixture/TestProducer.php
@@ -7,7 +7,7 @@ namespace SimPod\Kafka\Tests\Clients\Consumer\Fixture;
 use SimPod\Kafka\Clients\Producer\KafkaProducerWrapper;
 use SimPod\Kafka\Clients\Producer\ProducerConfig;
 
-use function Safe\gethostname;
+use function gethostname;
 
 final class TestProducer
 {

--- a/tests/Clients/Consumer/KafkaBatchConsumerTest.php
+++ b/tests/Clients/Consumer/KafkaBatchConsumerTest.php
@@ -13,8 +13,8 @@ use SimPod\Kafka\Clients\Consumer\KafkaConsumer;
 use SimPod\Kafka\Clients\Producer\KafkaProducerWrapper;
 use SimPod\Kafka\Tests\Clients\Consumer\Fixture\TestProducer;
 
-use function mt_rand;
 use function gethostname;
+use function mt_rand;
 
 #[CoversClass(KafkaConsumer::class)]
 #[CoversClass(KafkaProducerWrapper::class)]

--- a/tests/Clients/Consumer/KafkaBatchConsumerTest.php
+++ b/tests/Clients/Consumer/KafkaBatchConsumerTest.php
@@ -14,7 +14,7 @@ use SimPod\Kafka\Clients\Producer\KafkaProducerWrapper;
 use SimPod\Kafka\Tests\Clients\Consumer\Fixture\TestProducer;
 
 use function mt_rand;
-use function Safe\gethostname;
+use function gethostname;
 
 #[CoversClass(KafkaConsumer::class)]
 #[CoversClass(KafkaProducerWrapper::class)]

--- a/tests/Clients/Consumer/KafkaTest.php
+++ b/tests/Clients/Consumer/KafkaTest.php
@@ -10,8 +10,8 @@ use SimPod\Kafka\Clients\Consumer\ConsumerConfig;
 use SimPod\Kafka\Clients\Consumer\KafkaConsumer;
 use SimPod\Kafka\Tests\Clients\Consumer\Fixture\TestProducer;
 
-use function mt_rand;
 use function gethostname;
+use function mt_rand;
 
 use const RD_KAFKA_RESP_ERR__PARTITION_EOF;
 use const RD_KAFKA_RESP_ERR__TIMED_OUT;

--- a/tests/Clients/Consumer/KafkaTest.php
+++ b/tests/Clients/Consumer/KafkaTest.php
@@ -11,7 +11,7 @@ use SimPod\Kafka\Clients\Consumer\KafkaConsumer;
 use SimPod\Kafka\Tests\Clients\Consumer\Fixture\TestProducer;
 
 use function mt_rand;
-use function Safe\gethostname;
+use function gethostname;
 
 use const RD_KAFKA_RESP_ERR__PARTITION_EOF;
 use const RD_KAFKA_RESP_ERR__TIMED_OUT;


### PR DESCRIPTION
## Summary
- Remove `thecodingmachine/safe` from `require` and `thecodingmachine/phpstan-safe-rule` from `require-dev`
- Replace all `use function Safe\*` imports with native PHP function imports (`pcntl_signal`, `pcntl_sigprocmask`, `pcntl_signal_dispatch`, `gethostname`)
- Remove the related phpstan ignore pattern for Safe's DateTime warning

On PHP 8.4, these Safe wrappers add no practical value: `pcntl_signal()` always returns `true` since PHP 7.1, and the other pcntl/gethostname functions won't fail when called with valid arguments.

## Test plan
- [ ] Verify CI passes (phpstan, phpunit, coding standard checks)
- [ ] Confirm no remaining references to `thecodingmachine/safe`

https://claude.ai/code/session_017hc6ALwad31oDqqBzEy2UL