### PR TITLE
Use caret version constraints for phpstan packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
         "cdn77/coding-standard": "^7.4",
         "infection/infection": "^0.32.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "2.1.44",
-        "phpstan/phpstan-phpunit": "2.0.16",
-        "phpstan/phpstan-strict-rules": "2.0.10",
+        "phpstan/phpstan": "^2.1.44",
+        "phpstan/phpstan-phpunit": "^2.0.16",
+        "phpstan/phpstan-strict-rules": "^2.0.10",
         "phpunit/phpunit": "^13.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Changed `phpstan/phpstan`, `phpstan/phpstan-phpunit`, and `phpstan/phpstan-strict-rules` from fixed version constraints to caret (`^`) constraints
- This allows automatic minor and patch updates instead of requiring manual version bumps

## Test plan
- [ ] Verify `composer install` / `composer update` works with the new constraints
- [ ] Verify phpstan analysis still passes

https://claude.ai/code/session_01E4TZNgefJzQ8RxX1LdRNP1